### PR TITLE
改小错误

### DIFF
--- a/endingScene.h
+++ b/endingScene.h
@@ -3,7 +3,7 @@
 
 #include "cocos2d.h"
 #include "MenuLayer.h"
-#include "GameLevelLayer.h"
+#include "GameLayer.h"
 #include"SimpleAudioEngine.h"
 USING_NS_CC;
 


### PR DESCRIPTION
include文件名错误
#include "GameLevelLayer.h" 错误
应当为
#include "GameLayer.h"